### PR TITLE
fix(autorelease): fix issue with npm-autorelease command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -541,7 +541,8 @@
     "conventional-changelog-preset-loader": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz",
-      "integrity": "sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ=="
+      "integrity": "sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ==",
+      "dev": true
     },
     "conventional-changelog-writer": {
       "version": "4.0.3",
@@ -571,6 +572,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
       "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
+      "dev": true,
       "requires": {
         "is-subset": "^0.1.1",
         "modify-values": "^1.0.0"
@@ -580,6 +582,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
       "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+      "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
         "is-text-path": "^1.0.0",
@@ -591,18 +594,264 @@
       }
     },
     "conventional-recommended-bump": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz",
-      "integrity": "sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
+      "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
       "requires": {
-        "concat-stream": "^1.6.0",
-        "conventional-changelog-preset-loader": "^2.0.2",
-        "conventional-commits-filter": "^2.0.1",
-        "conventional-commits-parser": "^3.0.1",
-        "git-raw-commits": "2.0.0",
-        "git-semver-tags": "^2.0.2",
-        "meow": "^4.0.0",
-        "q": "^1.5.1"
+        "concat-stream": "^1.4.10",
+        "conventional-commits-filter": "^1.1.1",
+        "conventional-commits-parser": "^2.1.1",
+        "git-raw-commits": "^1.3.0",
+        "git-semver-tags": "^1.3.0",
+        "meow": "^3.3.0",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "conventional-commits-filter": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
+          "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
+          "requires": {
+            "is-subset": "^0.1.1",
+            "modify-values": "^1.0.0"
+          }
+        },
+        "conventional-commits-parser": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+          "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+          "requires": {
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^1.0.0",
+            "lodash": "^4.2.1",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^2.0.0",
+            "trim-off-newlines": "^1.0.0"
+          },
+          "dependencies": {
+            "meow": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+              "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+              "requires": {
+                "camelcase-keys": "^4.0.0",
+                "decamelize-keys": "^1.0.0",
+                "loud-rejection": "^1.0.0",
+                "minimist": "^1.1.3",
+                "minimist-options": "^3.0.1",
+                "normalize-package-data": "^2.3.4",
+                "read-pkg-up": "^3.0.0",
+                "redent": "^2.0.0",
+                "trim-newlines": "^2.0.0"
+              }
+            }
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "git-raw-commits": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+          "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+          "requires": {
+            "dargs": "^4.0.1",
+            "lodash.template": "^4.0.2",
+            "meow": "^4.0.0",
+            "split2": "^2.0.0",
+            "through2": "^2.0.0"
+          },
+          "dependencies": {
+            "meow": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+              "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+              "requires": {
+                "camelcase-keys": "^4.0.0",
+                "decamelize-keys": "^1.0.0",
+                "loud-rejection": "^1.0.0",
+                "minimist": "^1.1.3",
+                "minimist-options": "^3.0.1",
+                "normalize-package-data": "^2.3.4",
+                "read-pkg-up": "^3.0.0",
+                "redent": "^2.0.0",
+                "trim-newlines": "^2.0.0"
+              }
+            }
+          }
+        },
+        "git-semver-tags": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
+          "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
+          "requires": {
+            "meow": "^4.0.0",
+            "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "meow": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+              "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+              "requires": {
+                "camelcase-keys": "^4.0.0",
+                "decamelize-keys": "^1.0.0",
+                "loud-rejection": "^1.0.0",
+                "minimist": "^1.1.3",
+                "minimist-options": "^3.0.1",
+                "normalize-package-data": "^2.3.4",
+                "read-pkg-up": "^3.0.0",
+                "redent": "^2.0.0",
+                "trim-newlines": "^2.0.0"
+              }
+            }
+          }
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+        },
+        "meow": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          },
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+              "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+              "requires": {
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              }
+            },
+            "redent": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+              "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+              "requires": {
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
+              }
+            },
+            "trim-newlines": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+              "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+            }
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -1283,8 +1532,7 @@
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -1305,6 +1553,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
       "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+      "dev": true,
       "requires": {
         "dargs": "^4.0.1",
         "lodash.template": "^4.0.2",
@@ -1335,6 +1584,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
       "integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
+      "dev": true,
       "requires": {
         "meow": "^4.0.0",
         "semver": "^5.5.0"
@@ -1717,7 +1967,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -1805,8 +2054,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -1969,6 +2217,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
       "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+      "dev": true,
       "requires": {
         "camelcase-keys": "^4.0.0",
         "decamelize-keys": "^1.0.0",
@@ -2126,8 +2375,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -2311,14 +2559,12 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -2410,7 +2656,8 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -2494,7 +2741,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "colors": "~0.6.0-1",
-    "conventional-recommended-bump": "^4.0.4",
+    "conventional-recommended-bump": "^1.0.0",
     "cross-spawn": "^6.0.5",
     "minimist": "^1.2.0",
     "simple-git": "^1.70.0"


### PR DESCRIPTION
npm-autorelease command was failing because "result.releaseType" was undefined. The root cause
of this is that the `conventional-recommended-bump` package has a bug in versions >2.X. Rolling back the version
of this package to 1.0.0 resolves the problem.